### PR TITLE
Clipboard history is not saved on App exit

### DIFF
--- a/project/AppController.m
+++ b/project/AppController.m
@@ -744,6 +744,8 @@ fail:
 			];
     }
     [saveDict setObject:jcListArray forKey:@"jcList"];
+
+	[saveDict writeToFile:[path stringByAppendingString:@"/JCEngine.save"] atomically:true];
 }
 
 - (void)setHotKeyPreferenceForRecorder:(SRRecorderControl *)aRecorder


### PR DESCRIPTION
It looks the code was removed accidentally; I reversed the change.

Sorry again for the duplicate pull request.
