### PR TITLE
Use brew install --cask jumpcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@ permalink: /index.html
         or install using <a href="https://brew.sh">Homebrew</a>:
     </p>
     <p><pre><code>brew tap homebrew/cask
-brew cask install jumpcut</code></pre>
+brew install --cask jumpcut</code></pre>
     </p>
     <p>
         Jumpcut currently supports versions of macOS from 10.11 (El Capitan)


### PR DESCRIPTION
Calling brew cask install is disabled! Use brew install [--cask] instead.