### PR TITLE
Add optional extended clipping workflow tools

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,275 @@
+# Jumpcut Handover
+
+This handover describes the local Jumpcut fork work completed for the extended
+clipping workflow, the opt-in preference that now gates those additions, the
+installed app update, and the GitHub release artifact.
+
+## Scope Completed
+
+- Added saving/export actions for clippings.
+- Increased the optional clipping history capacity from 99 to 500.
+- Added favourites for clippings.
+- Added a Hotkey preferences checkbox so the extra fork-only features are
+  opt-in.
+- Updated About Jumpcut and the README with usage notes.
+- Installed the locally built app over `/Applications/Jumpcut.app` without
+  changing the existing clipping store.
+- Published the implementation to `origin/master`.
+- Prepared a GitHub release asset for tag `v0.84-nyimbi.1`.
+
+Feature commit before this handover:
+
+```text
+ffe31de Keep Jumpcut minimal until extended clipping tools are enabled
+```
+
+## New User Capabilities
+
+### Extended Features Opt-In
+
+The fork-only features are off by default for ordinary installs. They are
+enabled with:
+
+```text
+Preferences > Hotkey > Enable extended clipping actions and 500-item history
+```
+
+When the checkbox is off:
+
+- The visible menus stay close to upstream Jumpcut.
+- Save/export actions are not shown.
+- Favourites actions and `[F]` markers are not shown.
+- The effective clipping history limit is capped at 99.
+
+When the checkbox is on:
+
+- History can retain up to 500 clippings.
+- Individual clippings can be added to or removed from Favourites.
+- Favourite clippings are marked with `[F]`.
+- A dedicated Favourites submenu is available.
+- Selected clippings can be saved to a text file.
+- All clippings can be saved to one text file.
+- All clippings can be saved as separate text files.
+
+Existing users who already had `rememberNum` above 99 are migrated with
+`extendedFeaturesEnabled` set to true. This avoids silently truncating an
+existing larger clipping history after upgrade.
+
+### Saving Clippings
+
+Extended mode adds these menu actions:
+
+- `Save item to file...` from an individual clipping's alternate submenu.
+- `Save All to File...` from the fixed menu area.
+- `Save All as Files...` from the fixed menu area.
+
+Filenames for individual exports are derived from the clipping text, sanitized,
+and prefixed with a one-based index such as `001-example.txt`.
+
+### Favourites
+
+To favourite a clipping after enabling extended mode:
+
+1. Open Jumpcut's alternate clipping menu.
+2. Hover the clipping.
+3. Choose `Add to Favourites`.
+
+The alternate menu behavior depends on existing Jumpcut preferences, for
+example right-click or Shift-click on the menu bar icon.
+
+## Code Changes
+
+### `Jumpcut/Jumpcut/Settings.swift`
+
+- Added `SettingsPath.extendedFeaturesEnabled`.
+- Registered the default value as `false`.
+- Added helper methods:
+  - `Settings.extendedFeaturesEnabled()`
+  - `Settings.maximumRememberNum()`
+  - `Settings.defaultRememberNum()`
+  - `Settings.effectiveRememberNum()`
+- Added migration logic that enables extended features if an existing
+  `rememberNum` value is already above 99.
+- Widened stepper value display space so `500` renders cleanly.
+
+### `Jumpcut/Jumpcut/Preferences/HotkeyPreferenceViewController.swift`
+
+- Added the opt-in checkbox in the Hotkey pane.
+- Increased the pane height to fit the new checkbox.
+- When the checkbox is turned off, `rememberNum` is clamped back to 99 if it was
+  above the standard limit.
+
+### `Jumpcut/Jumpcut/Preferences/GeneralPreferenceViewController.swift`
+
+- Made the Remembering stepper maximum dynamic:
+  - 99 when extended mode is off.
+  - 500 when extended mode is on.
+
+### `Jumpcut/Jumpcut/Clippings.swift`
+
+- Added optional `Favorite` persistence to `JCListItem`.
+- Added `PositionedClipping`.
+- Added `Clipping.isFavorite`.
+- Added stack/store APIs:
+  - `syncSettings()`
+  - `allItems()`
+  - `favoriteItems()`
+  - `toggleFavorite(position:)`
+- Changed clipping history sizing to use `Settings.effectiveRememberNum()`.
+- Preserved backwards compatibility with older saved plist files by treating
+  missing `Favorite` values as `false`.
+- Fixed bounds checks that could incorrectly allow `position == count`.
+- Fixed persisted `rememberNum` to write the effective remember limit rather
+  than the display count.
+
+### `Jumpcut/Jumpcut/MenuManager.swift`
+
+- Added stable clipping positions through `NSMenuItem.representedObject`.
+- Added `[F]` title markers when extended mode is enabled.
+- Added Favourites submenu when extended mode is enabled.
+- Added save/export menu items when extended mode is enabled.
+- Kept the standard Clear All, About, Preferences, and Quit actions available in
+  both modes.
+
+### `Jumpcut/Jumpcut/Interactions.swift`
+
+- Added handlers for:
+  - `menuToggleFavorite(sender:)`
+  - `menuSaveItemToFile(sender:)`
+  - `saveAllToFile(sender:)`
+  - `saveAllAsFiles(sender:)`
+- Added save panel/open panel handling for clipping exports.
+- Added sanitized default filename generation and collision-safe output URLs.
+- Added runtime guards so extended actions no-op if invoked while extended mode
+  is disabled.
+- Updated menu index extraction to prefer `representedObject` so submenu actions
+  target the correct clipping.
+
+### `Jumpcut/Jumpcut/AppDelegate.swift`
+
+- Calls `stack.syncSettings()` when user defaults change so menu and clipping
+  history limits respond to preference changes.
+
+### `Jumpcut/JumpcutTests/JumpcutTests.swift`
+
+- Replaced template tests with focused clipping behavior tests.
+- Added coverage for:
+  - 500 clipping retention when extended mode is enabled.
+  - 99 clipping cap when extended mode is disabled.
+  - trimming on remember-limit changes.
+  - favourite toggling and favourites moving with their clipping.
+- Tests preserve and restore relevant user defaults.
+
+### `Jumpcut/Jumpcut/Credits.html`
+
+- Added About-window instructions for enabling extended mode and adding
+  Favourites.
+
+### `README.md`
+
+- Documented the fork-only capabilities.
+- Documented that they are opt-in through the Hotkey preferences pane.
+- Added the requested note that the changes were made for personal use, sent as
+  a PR, are probably not useful to others, and bend Jumpcut's minimalism.
+
+## Installed App Notes
+
+The installed app was replaced at:
+
+```text
+/Applications/Jumpcut.app
+```
+
+The existing clipping store was preserved at:
+
+```text
+~/Library/Application Support/Jumpcut/JCEngine.save
+```
+
+The clipping store SHA-256 stayed unchanged during the final install:
+
+```text
+472cce26061941f83c2262f4a4a4640a5e128d5008d1333a8b19b23ea43a5b07
+```
+
+Final install backup:
+
+```text
+/private/tmp/jumpcut-backup-20260518-014231
+```
+
+The installed app was ad-hoc signed after installation because the local machine
+does not have a Mac Development signing identity available. `open
+/Applications/Jumpcut.app` returned success after signing.
+
+## Verification Performed
+
+```text
+git diff --check
+```
+
+Passed.
+
+```text
+xcodebuild test -project Jumpcut/Jumpcut.xcodeproj -scheme Jumpcut -destination 'platform=macOS' -derivedDataPath ./DerivedData CODE_SIGNING_ALLOWED=NO MACOSX_DEPLOYMENT_TARGET=10.13
+```
+
+Passed.
+
+```text
+xcodebuild build -project Jumpcut/Jumpcut.xcodeproj -scheme Jumpcut -configuration Release -destination 'platform=macOS' -derivedDataPath ./DerivedData CODE_SIGNING_ALLOWED=NO MACOSX_DEPLOYMENT_TARGET=10.13
+```
+
+Passed.
+
+```text
+codesign --verify --deep --strict --verbose=2 /Applications/Jumpcut.app
+```
+
+Passed after applying the local ad-hoc signature.
+
+## Release Artifact
+
+Release tag:
+
+```text
+v0.84-nyimbi.1
+```
+
+Release asset:
+
+```text
+Jumpcut-0.84-nyimbi.1-macOS.zip
+```
+
+Local release asset path:
+
+```text
+/private/tmp/jumpcut-release-v0.84-nyimbi.1/Jumpcut-0.84-nyimbi.1-macOS.zip
+```
+
+Asset SHA-256:
+
+```text
+9b7d9e1df76ec24e4217aaedd6f58f3cc8a51d32508f746b17e91f25ab52e578
+```
+
+## Known Caveats
+
+- The release app is ad-hoc signed, not signed with an Apple Developer
+  certificate.
+- Plain local Xcode builds without overrides are blocked by existing local
+  signing/deployment-target constraints. The verified commands use
+  `CODE_SIGNING_ALLOWED=NO` and `MACOSX_DEPLOYMENT_TARGET=10.13`.
+- The release asset is an app zip for macOS, not a notarized installer package.
+- Existing users with `rememberNum > 99` are intentionally migrated into
+  extended mode to preserve their clipping history.
+
+## Future Maintenance Notes
+
+- Keep new fork-only clipping actions behind `Settings.extendedFeaturesEnabled()`
+  unless the behavior is intentionally upstream-minimal.
+- Preserve the optional `Favorite` field as optional so older clipping save
+  files continue to decode.
+- If a signed public distribution is needed, rebuild with a valid Apple
+  Developer identity and notarize before uploading a replacement release asset.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -9,6 +9,7 @@ installed app update, and the GitHub release artifact.
 - Added saving/export actions for clippings.
 - Increased the optional clipping history capacity from 99 to 500.
 - Added favourites for clippings.
+- Added bold, italic, and color labels for clippings.
 - Added a Hotkey preferences checkbox so the extra fork-only features are
   opt-in.
 - Updated About Jumpcut and the README with usage notes.
@@ -38,7 +39,7 @@ When the checkbox is off:
 
 - The visible menus stay close to upstream Jumpcut.
 - Save/export actions are not shown.
-- Favourites actions and `[F]` markers are not shown.
+- Favourites, bold, italic, color, and `[F]` markers are not shown.
 - The effective clipping history limit is capped at 99.
 
 When the checkbox is on:
@@ -46,6 +47,10 @@ When the checkbox is on:
 - History can retain up to 500 clippings.
 - Individual clippings can be added to or removed from Favourites.
 - Favourite clippings are marked with `[F]`.
+- Individual clippings can be made bold, made italic, or assigned a palette
+  color.
+- Bold, italic, and color labels are visible in the main clipping menu, the
+  alternate menu, and the Favourites submenu.
 - A dedicated Favourites submenu is available.
 - Selected clippings can be saved to a text file.
 - All clippings can be saved to one text file.
@@ -77,6 +82,17 @@ To favourite a clipping after enabling extended mode:
 The alternate menu behavior depends on existing Jumpcut preferences, for
 example right-click or Shift-click on the menu bar icon.
 
+### Visual Labels
+
+To make a clipping easier to find after enabling extended mode:
+
+1. Open Jumpcut's alternate clipping menu.
+2. Hover the clipping.
+3. Choose `Make Bold`, `Make Italic`, or a color from `Color`.
+
+These labels are persisted with the clipping and move with it. They are visible
+where the clipping is listed, including the primary menu.
+
 ## Code Changes
 
 ### `Jumpcut/Jumpcut/Settings.swift`
@@ -107,14 +123,20 @@ example right-click or Shift-click on the menu bar icon.
 
 ### `Jumpcut/Jumpcut/Clippings.swift`
 
-- Added optional `Favorite` persistence to `JCListItem`.
+- Added optional `Favorite`, `Bold`, `Italic`, and `Color` persistence to
+  `JCListItem`.
 - Added `PositionedClipping`.
-- Added `Clipping.isFavorite`.
+- Added `Clipping.isFavorite`, `Clipping.isBold`, `Clipping.isItalic`, and
+  `Clipping.labelColor`.
+- Added `ClippingLabelColor` for the fixed color palette.
 - Added stack/store APIs:
   - `syncSettings()`
   - `allItems()`
   - `favoriteItems()`
   - `toggleFavorite(position:)`
+  - `toggleBold(position:)`
+  - `toggleItalic(position:)`
+  - `setLabelColor(position:color:)`
 - Changed clipping history sizing to use `Settings.effectiveRememberNum()`.
 - Preserved backwards compatibility with older saved plist files by treating
   missing `Favorite` values as `false`.
@@ -125,8 +147,10 @@ example right-click or Shift-click on the menu bar icon.
 ### `Jumpcut/Jumpcut/MenuManager.swift`
 
 - Added stable clipping positions through `NSMenuItem.representedObject`.
+- Added styled menu titles when extended mode is enabled.
 - Added `[F]` title markers when extended mode is enabled.
 - Added Favourites submenu when extended mode is enabled.
+- Added bold, italic, and color controls to the alternate clipping menu.
 - Added save/export menu items when extended mode is enabled.
 - Kept the standard Clear All, About, Preferences, and Quit actions available in
   both modes.
@@ -135,6 +159,9 @@ example right-click or Shift-click on the menu bar icon.
 
 - Added handlers for:
   - `menuToggleFavorite(sender:)`
+  - `menuToggleBold(sender:)`
+  - `menuToggleItalic(sender:)`
+  - `menuSetLabelColor(sender:)`
   - `menuSaveItemToFile(sender:)`
   - `saveAllToFile(sender:)`
   - `saveAllAsFiles(sender:)`
@@ -158,6 +185,7 @@ example right-click or Shift-click on the menu bar icon.
   - 99 clipping cap when extended mode is disabled.
   - trimming on remember-limit changes.
   - favourite toggling and favourites moving with their clipping.
+  - bold, italic, and color labels moving with their clipping.
 - Tests preserve and restore relevant user defaults.
 
 ### `Jumpcut/Jumpcut/Credits.html`
@@ -169,6 +197,7 @@ example right-click or Shift-click on the menu bar icon.
 
 - Documented the fork-only capabilities.
 - Documented that they are opt-in through the Hotkey preferences pane.
+- Documented bold, italic, and color labels.
 - Added the requested note that the changes were made for personal use, sent as
   a PR, are probably not useful to others, and bend Jumpcut's minimalism.
 
@@ -230,28 +259,28 @@ Passed after applying the local ad-hoc signature.
 
 ## Release Artifact
 
-Release tag:
+Latest release tag:
 
 ```text
-v0.84-nyimbi.1
+v0.84-nyimbi.2
 ```
 
 Release asset:
 
 ```text
-Jumpcut-0.84-nyimbi.1-macOS.zip
+Jumpcut-0.84-nyimbi.2-macOS.zip
 ```
 
 Local release asset path:
 
 ```text
-/private/tmp/jumpcut-release-v0.84-nyimbi.1/Jumpcut-0.84-nyimbi.1-macOS.zip
+/private/tmp/jumpcut-release-v0.84-nyimbi.2/Jumpcut-0.84-nyimbi.2-macOS.zip
 ```
 
 Asset SHA-256:
 
 ```text
-9b7d9e1df76ec24e4217aaedd6f58f3cc8a51d32508f746b17e91f25ab52e578
+a73e2da5f316c5733e79cfc2ec2498fa0ee5bae9028f11b48c11067c1a8abb4d
 ```
 
 ## Known Caveats
@@ -269,7 +298,7 @@ Asset SHA-256:
 
 - Keep new fork-only clipping actions behind `Settings.extendedFeaturesEnabled()`
   unless the behavior is intentionally upstream-minimal.
-- Preserve the optional `Favorite` field as optional so older clipping save
-  files continue to decode.
+- Preserve the optional `Favorite`, `Bold`, `Italic`, and `Color` fields as
+  optional so older clipping save files continue to decode.
 - If a signed public distribution is needed, rebuild with a valid Apple
   Developer identity and notarize before uploading a replacement release asset.

--- a/Jumpcut/Jumpcut/AppDelegate.swift
+++ b/Jumpcut/Jumpcut/AppDelegate.swift
@@ -155,6 +155,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, SPUStandardU
         // the menu bar's visibility, rather than a more detailed examination
         // of what has changed.
         statusItem.setVisibility()
+        stack.syncSettings()
         menu.rebuild(stack: stack)
     }
 

--- a/Jumpcut/Jumpcut/AppDelegate.swift
+++ b/Jumpcut/Jumpcut/AppDelegate.swift
@@ -91,7 +91,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, SPUStandardU
 
         setObservers()
 
-        if !AXIsProcessTrusted() &&
+        if !Settings.pasteAccessibilityTrusted() &&
             UserDefaults.standard.value(forKey: SettingsPath.askForAccessibility.rawValue) as? Bool ?? true {
                 #if DEBUG
                 // Running in debug mode in Xcode doesn't seem to

--- a/Jumpcut/Jumpcut/Clippings.swift
+++ b/Jumpcut/Jumpcut/Clippings.swift
@@ -32,10 +32,16 @@ struct JCEngine: Codable {
 // swiftlint:disable identifier_name
 struct JCListItem: Codable {
     let Contents: String
+    let Favorite: Bool?
     let Position: Int
     let `Type`: String
 }
 // swiftlint:enable identifier_name
+
+struct PositionedClipping {
+    let position: Int
+    let clipping: Clipping
+}
 
 public class ClippingStack: NSObject {
     private var store: ClippingStore
@@ -51,9 +57,7 @@ public class ClippingStack: NSObject {
     override init() {
         self.store = ClippingStore()
         super.init()
-        self.store.maxLength = UserDefaults.standard.value(
-            forKey: SettingsPath.rememberNum.rawValue
-        ) as? Int ?? 99
+        syncSettings()
     }
 
     func checkWriteAccess() -> Bool {
@@ -71,6 +75,10 @@ public class ClippingStack: NSObject {
 
     func clear() {
         store.clear()
+    }
+
+    func syncSettings() {
+        store.maxLength = Settings.effectiveRememberNum()
     }
 
     func delete() {
@@ -126,6 +134,18 @@ public class ClippingStack: NSObject {
         return store.itemAt(position: position)
     }
 
+    func allItems() -> [Clipping] {
+        return Array(store.firstItems(n: store.count))
+    }
+
+    func favoriteItems() -> [PositionedClipping] {
+        return store.favoriteItems()
+    }
+
+    func toggleFavorite(position: Int) {
+        store.toggleFavorite(position: position)
+    }
+
     func moveItemToTop(position: Int) {
         store.moveItemToTop(position: position)
     }
@@ -148,10 +168,12 @@ public class Clipping: NSObject {
     public let fullText: String
     public var shortenedText: String
     public var length: Int
+    public var isFavorite: Bool
     private let defaultLength = 40
 
-    init(string: String) {
+    init(string: String, isFavorite: Bool = false) {
         fullText = string
+        self.isFavorite = isFavorite
         length = defaultLength
         shortenedText = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
         shortenedText = shortenedText.components(separatedBy: .newlines)[0]
@@ -173,8 +195,12 @@ private class ClippingStore: NSObject {
         get { return _maxLength }
         set {
             let newValueWithMin = newValue < 10 ? 10 : newValue
+            let previousCount = clippings.count
             clippings = Array(self.firstItems(n: newValueWithMin))
             _maxLength = newValueWithMin
+            if clippings.count != previousCount {
+                writeClippings()
+            }
         }
     }
 
@@ -202,6 +228,7 @@ private class ClippingStore: NSObject {
     override init() {
         // TK: We will eventually be switching this out to use SQLite3, but for
         // now we'll use a hardcoded path to a property list.
+        _maxLength = Settings.effectiveRememberNum()
         skipSave = UserDefaults.standard.value(forKey: SettingsPath.skipSave.rawValue) as? Bool ?? false
         if let jumpcutSupportDir = ClippingStore.getSupportDir() {
             plistUrl = jumpcutSupportDir.appendingPathComponent("JCEngine.save")
@@ -247,7 +274,7 @@ private class ClippingStore: NSObject {
                         in: .whitespacesAndNewlines
                     ).isEmpty
                     if !clipIsEmpty || allowWhitespace {
-                        self.add(item: clipDict.Contents)
+                        self.add(item: clipDict.Contents, isFavorite: clipDict.Favorite ?? false)
                     }
                 }
             } catch {
@@ -267,13 +294,18 @@ private class ClippingStore: NSObject {
         var items: [JCListItem] = []
         var counter = 0
         for clip in clippings {
-            items.append(JCListItem(Contents: clip.fullText, Position: counter, Type: "NSStringPboardType"))
+            items.append(JCListItem(
+                Contents: clip.fullText,
+                Favorite: clip.isFavorite ? true : nil,
+                Position: counter,
+                Type: "NSStringPboardType"
+            ))
             counter += 1
         }
         let data = JCEngine(
             displayNum: UserDefaults.standard.value(forKey: SettingsPath.displayNum.rawValue) as? Int ?? 10,
             jcList: items,
-            rememberNum: UserDefaults.standard.value(forKey: SettingsPath.displayNum.rawValue) as? Int ?? 99,
+            rememberNum: Settings.effectiveRememberNum(),
             version: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
         )
         let encoder = PropertyListEncoder()
@@ -286,8 +318,8 @@ private class ClippingStore: NSObject {
         }
     }
 
-    func add(item: String) {
-        clippings.insert(Clipping(string: item), at: 0)
+    func add(item: String, isFavorite: Bool = false) {
+        clippings.insert(Clipping(string: item, isFavorite: isFavorite), at: 0)
         if clippings.count > maxLength {
             clippings.removeLast()
         }
@@ -305,7 +337,7 @@ private class ClippingStore: NSObject {
         // Don't move from an invalid position; also, position 0
         // is a null operation, because it's already at the top.
         guard !clippings.isEmpty,
-            position <= clippings.count,
+            position < clippings.count,
             position > 0
         else {
             return
@@ -316,18 +348,32 @@ private class ClippingStore: NSObject {
     }
 
     func itemAt(position: Int) -> Clipping? {
-        if clippings.isEmpty || position > clippings.count {
+        if clippings.isEmpty || position >= clippings.count {
             return nil
         }
         return clippings[position]
     }
 
     func removeItem(position: Int) {
-        if clippings.isEmpty || position > clippings.count {
+        if clippings.isEmpty || position >= clippings.count {
             return
         }
         clippings.remove(at: position)
         // TK: When we have SQLite backing, we'll want to change this.
+        writeClippings()
+    }
+
+    func favoriteItems() -> [PositionedClipping] {
+        return clippings.enumerated().compactMap { index, clipping in
+            clipping.isFavorite ? PositionedClipping(position: index, clipping: clipping) : nil
+        }
+    }
+
+    func toggleFavorite(position: Int) {
+        guard let clipping = itemAt(position: position) else {
+            return
+        }
+        clipping.isFavorite = !clipping.isFavorite
         writeClippings()
     }
 

--- a/Jumpcut/Jumpcut/Clippings.swift
+++ b/Jumpcut/Jumpcut/Clippings.swift
@@ -31,8 +31,11 @@ struct JCEngine: Codable {
 // These names are from our original Objective-C implementation.
 // swiftlint:disable identifier_name
 struct JCListItem: Codable {
+    let Bold: Bool?
+    let Color: String?
     let Contents: String
     let Favorite: Bool?
+    let Italic: Bool?
     let Position: Int
     let `Type`: String
 }
@@ -41,6 +44,39 @@ struct JCListItem: Codable {
 struct PositionedClipping {
     let position: Int
     let clipping: Clipping
+}
+
+enum ClippingLabelColor: String, CaseIterable {
+    case red
+    case orange
+    case yellow
+    case green
+    case blue
+    case purple
+    case gray
+
+    var title: String {
+        return rawValue.capitalized
+    }
+
+    var menuColor: NSColor {
+        switch self {
+        case .red:
+            return NSColor(calibratedRed: 0.82, green: 0.18, blue: 0.18, alpha: 1.0)
+        case .orange:
+            return NSColor(calibratedRed: 0.85, green: 0.38, blue: 0.06, alpha: 1.0)
+        case .yellow:
+            return NSColor(calibratedRed: 0.62, green: 0.48, blue: 0.08, alpha: 1.0)
+        case .green:
+            return NSColor(calibratedRed: 0.12, green: 0.52, blue: 0.22, alpha: 1.0)
+        case .blue:
+            return NSColor(calibratedRed: 0.12, green: 0.34, blue: 0.78, alpha: 1.0)
+        case .purple:
+            return NSColor(calibratedRed: 0.44, green: 0.24, blue: 0.68, alpha: 1.0)
+        case .gray:
+            return NSColor(calibratedWhite: 0.38, alpha: 1.0)
+        }
+    }
 }
 
 public class ClippingStack: NSObject {
@@ -146,6 +182,18 @@ public class ClippingStack: NSObject {
         store.toggleFavorite(position: position)
     }
 
+    func toggleBold(position: Int) {
+        store.toggleBold(position: position)
+    }
+
+    func toggleItalic(position: Int) {
+        store.toggleItalic(position: position)
+    }
+
+    func setLabelColor(position: Int, color: ClippingLabelColor?) {
+        store.setLabelColor(position: position, color: color)
+    }
+
     func moveItemToTop(position: Int) {
         store.moveItemToTop(position: position)
     }
@@ -169,11 +217,23 @@ public class Clipping: NSObject {
     public var shortenedText: String
     public var length: Int
     public var isFavorite: Bool
+    public var isBold: Bool
+    public var isItalic: Bool
+    var labelColor: ClippingLabelColor?
     private let defaultLength = 40
 
-    init(string: String, isFavorite: Bool = false) {
+    init(
+        string: String,
+        isFavorite: Bool = false,
+        isBold: Bool = false,
+        isItalic: Bool = false,
+        labelColor: ClippingLabelColor? = nil
+    ) {
         fullText = string
         self.isFavorite = isFavorite
+        self.isBold = isBold
+        self.isItalic = isItalic
+        self.labelColor = labelColor
         length = defaultLength
         shortenedText = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
         shortenedText = shortenedText.components(separatedBy: .newlines)[0]
@@ -274,7 +334,13 @@ private class ClippingStore: NSObject {
                         in: .whitespacesAndNewlines
                     ).isEmpty
                     if !clipIsEmpty || allowWhitespace {
-                        self.add(item: clipDict.Contents, isFavorite: clipDict.Favorite ?? false)
+                        self.add(
+                            item: clipDict.Contents,
+                            isFavorite: clipDict.Favorite ?? false,
+                            isBold: clipDict.Bold ?? false,
+                            isItalic: clipDict.Italic ?? false,
+                            labelColor: ClippingLabelColor(rawValue: clipDict.Color ?? "")
+                        )
                     }
                 }
             } catch {
@@ -295,8 +361,11 @@ private class ClippingStore: NSObject {
         var counter = 0
         for clip in clippings {
             items.append(JCListItem(
+                Bold: clip.isBold ? true : nil,
+                Color: clip.labelColor?.rawValue,
                 Contents: clip.fullText,
                 Favorite: clip.isFavorite ? true : nil,
+                Italic: clip.isItalic ? true : nil,
                 Position: counter,
                 Type: "NSStringPboardType"
             ))
@@ -318,8 +387,23 @@ private class ClippingStore: NSObject {
         }
     }
 
-    func add(item: String, isFavorite: Bool = false) {
-        clippings.insert(Clipping(string: item, isFavorite: isFavorite), at: 0)
+    func add(
+        item: String,
+        isFavorite: Bool = false,
+        isBold: Bool = false,
+        isItalic: Bool = false,
+        labelColor: ClippingLabelColor? = nil
+    ) {
+        clippings.insert(
+            Clipping(
+                string: item,
+                isFavorite: isFavorite,
+                isBold: isBold,
+                isItalic: isItalic,
+                labelColor: labelColor
+            ),
+            at: 0
+        )
         if clippings.count > maxLength {
             clippings.removeLast()
         }
@@ -374,6 +458,30 @@ private class ClippingStore: NSObject {
             return
         }
         clipping.isFavorite = !clipping.isFavorite
+        writeClippings()
+    }
+
+    func toggleBold(position: Int) {
+        guard let clipping = itemAt(position: position) else {
+            return
+        }
+        clipping.isBold = !clipping.isBold
+        writeClippings()
+    }
+
+    func toggleItalic(position: Int) {
+        guard let clipping = itemAt(position: position) else {
+            return
+        }
+        clipping.isItalic = !clipping.isItalic
+        writeClippings()
+    }
+
+    func setLabelColor(position: Int, color: ClippingLabelColor?) {
+        guard let clipping = itemAt(position: position) else {
+            return
+        }
+        clipping.labelColor = color
         writeClippings()
     }
 

--- a/Jumpcut/Jumpcut/Constants.swift
+++ b/Jumpcut/Jumpcut/Constants.swift
@@ -13,7 +13,7 @@ struct Constants {
         Without this permission Jumpcut can place items on the pasteboard but \
         cannot paste.
 
-        To give permission, go to System Preferences → Security & Privacy → Privacy \
+        To give permission, go to System Settings → Privacy & Security \
         → Accessibility, add Jumpcut, make sure the checkbox is checked, and \
         restart Jumpcut.
         """

--- a/Jumpcut/Jumpcut/Credits.html
+++ b/Jumpcut/Jumpcut/Credits.html
@@ -7,7 +7,7 @@
     <title>Jumpcut Credits</title>
 </head>
 <body>
-<p><strong>Favourites:</strong> First enable <strong>Hotkey &gt; Enable extended clipping actions and 500-item history</strong> in Preferences. Then open Jumpcut's alternate clipping menu (for example, right-click or Shift-click the menu bar icon, depending on your preferences), hover the clipping, and choose <strong>Add to Favourites</strong>. Favourite clippings are marked with <strong>[F]</strong> and are available from the <strong>Favourites</strong> submenu.</p>
+<p><strong>Favourites and labels:</strong> First enable <strong>Hotkey &gt; Enable extended clipping actions and 500-item history</strong> in Preferences. Then open Jumpcut's alternate clipping menu (for example, right-click or Shift-click the menu bar icon, depending on your preferences), hover the clipping, and choose <strong>Add to Favourites</strong>, <strong>Make Bold</strong>, <strong>Make Italic</strong>, or a color from <strong>Color</strong>. Favourite clippings are marked with <strong>[F]</strong>, and bold, italic, and color labels are visible in the main menu, alternate menu, and <strong>Favourites</strong> submenu.</p>
 <p>Jumpcut is subject to the MIT License. Source code and license details are available on the application's <a href="https://github.com/snark/jumpcut">GitHub page</a>.</p>
 <p>Jumpcut is open source code built with open source code. Jumpcut incorporates the following libraries, used with gratitude:
     <ul>

--- a/Jumpcut/Jumpcut/Credits.html
+++ b/Jumpcut/Jumpcut/Credits.html
@@ -7,6 +7,7 @@
     <title>Jumpcut Credits</title>
 </head>
 <body>
+<p><strong>Favourites:</strong> First enable <strong>Hotkey &gt; Enable extended clipping actions and 500-item history</strong> in Preferences. Then open Jumpcut's alternate clipping menu (for example, right-click or Shift-click the menu bar icon, depending on your preferences), hover the clipping, and choose <strong>Add to Favourites</strong>. Favourite clippings are marked with <strong>[F]</strong> and are available from the <strong>Favourites</strong> submenu.</p>
 <p>Jumpcut is subject to the MIT License. Source code and license details are available on the application's <a href="https://github.com/snark/jumpcut">GitHub page</a>.</p>
 <p>Jumpcut is open source code built with open source code. Jumpcut incorporates the following libraries, used with gratitude:
     <ul>

--- a/Jumpcut/Jumpcut/Interactions.swift
+++ b/Jumpcut/Jumpcut/Interactions.swift
@@ -70,7 +70,7 @@ public class Interactions: NSObject {
         // Place the clipping on the top of the pasteboard, and 0.2 seconds
         // later, emit a Command-V event to paste.
         pasteboard.set(clipping.fullText)
-        guard AXIsProcessTrusted() else {
+        guard Settings.pasteAccessibilityTrusted(prompt: true) else {
             if !warnedAboutPasteAccessibility {
                 warnedAboutPasteAccessibility = true
                 delegate.showAccessibilityWarning()

--- a/Jumpcut/Jumpcut/Interactions.swift
+++ b/Jumpcut/Jumpcut/Interactions.swift
@@ -262,6 +262,35 @@ public class Interactions: NSObject {
         menu.rebuild(stack: stack)
     }
 
+    @objc public func menuToggleBold(sender: NSMenuItem!) {
+        guard Settings.extendedFeaturesEnabled() else {
+            return
+        }
+        let idx = extractIndex(menuItem: sender)
+        stack.toggleBold(position: idx)
+        menu.rebuild(stack: stack)
+    }
+
+    @objc public func menuToggleItalic(sender: NSMenuItem!) {
+        guard Settings.extendedFeaturesEnabled() else {
+            return
+        }
+        let idx = extractIndex(menuItem: sender)
+        stack.toggleItalic(position: idx)
+        menu.rebuild(stack: stack)
+    }
+
+    @objc public func menuSetLabelColor(sender: NSMenuItem!) {
+        guard Settings.extendedFeaturesEnabled() else {
+            return
+        }
+        let idx = extractIndex(menuItem: sender)
+        let rawValue = sender.representedObject as? String
+        let color = rawValue == "none" ? nil : ClippingLabelColor(rawValue: rawValue ?? "")
+        stack.setLabelColor(position: idx, color: color)
+        menu.rebuild(stack: stack)
+    }
+
     @objc public func menuSaveItemToFile(sender: NSMenuItem!) {
         guard Settings.extendedFeaturesEnabled() else {
             return

--- a/Jumpcut/Jumpcut/Interactions.swift
+++ b/Jumpcut/Jumpcut/Interactions.swift
@@ -19,6 +19,7 @@ public class Interactions: NSObject {
     weak private var menu: MenuManager!
     weak private var bezel: Bezel!
     weak private var delegate: AppDelegate!
+    private var warnedAboutPasteAccessibility = false
 
     init(bezel: Bezel, menu: MenuManager, pasteboard: Pasteboard, stack: ClippingStack) {
         self.pasteboard = pasteboard
@@ -68,7 +69,16 @@ public class Interactions: NSObject {
     func paste(_ clipping: Clipping) {
         // Place the clipping on the top of the pasteboard, and 0.2 seconds
         // later, emit a Command-V event to paste.
-        place(clipping)
+        pasteboard.set(clipping.fullText)
+        guard AXIsProcessTrusted() else {
+            if !warnedAboutPasteAccessibility {
+                warnedAboutPasteAccessibility = true
+                delegate.showAccessibilityWarning()
+            }
+            delegate.hide()
+            return
+        }
+        delegate.hide()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             self.pasteboard.fakeCommandV()
         }

--- a/Jumpcut/Jumpcut/Interactions.swift
+++ b/Jumpcut/Jumpcut/Interactions.swift
@@ -253,10 +253,90 @@ public class Interactions: NSObject {
         menu.rebuild(stack: stack)
     }
 
+    @objc public func menuToggleFavorite(sender: NSMenuItem!) {
+        guard Settings.extendedFeaturesEnabled() else {
+            return
+        }
+        let idx = extractIndex(menuItem: sender)
+        stack.toggleFavorite(position: idx)
+        menu.rebuild(stack: stack)
+    }
+
+    @objc public func menuSaveItemToFile(sender: NSMenuItem!) {
+        guard Settings.extendedFeaturesEnabled() else {
+            return
+        }
+        let idx = extractIndex(menuItem: sender)
+        guard let clipping = stack.itemAt(position: idx) else {
+            return
+        }
+        let panel = configuredSavePanel(name: defaultFilename(for: clipping, position: idx))
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else {
+                return
+            }
+            self.write(clipping.fullText, to: url)
+        }
+    }
+
+    @objc public func saveAllToFile(sender: AnyObject?) {
+        guard Settings.extendedFeaturesEnabled() else {
+            return
+        }
+        let clippings = stack.allItems()
+        guard !clippings.isEmpty else {
+            return
+        }
+        let panel = configuredSavePanel(name: "Jumpcut Clippings.txt")
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else {
+                return
+            }
+            let output = clippings.enumerated().map { index, clipping in
+                "----- Clipping \(index + 1) -----\n\(clipping.fullText)"
+            }.joined(separator: "\n\n")
+            self.write(output, to: url)
+        }
+    }
+
+    @objc public func saveAllAsFiles(sender: AnyObject?) {
+        guard Settings.extendedFeaturesEnabled() else {
+            return
+        }
+        let clippings = stack.allItems()
+        guard !clippings.isEmpty else {
+            return
+        }
+        let panel = NSOpenPanel()
+        panel.title = "Save All Clippings"
+        panel.prompt = "Save"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.begin { response in
+            guard response == .OK, let directory = panel.url else {
+                return
+            }
+            for (index, clipping) in clippings.enumerated() {
+                let filename = self.defaultFilename(for: clipping, position: index)
+                let url = self.uniqueURL(for: filename, in: directory)
+                self.write(clipping.fullText, to: url)
+            }
+        }
+    }
+
     private func extractIndex(menuItem: NSMenuItem!) -> Int {
         // Utility function to abstract over calling our menu-driven behaviors
         // for individual clippings from either the standard or the alternative
         // menu.
+        if let index = menuItem.representedObject as? Int {
+            return index
+        }
+        if let parent = menuItem.parent,
+           let index = parent.representedObject as? Int {
+            return index
+        }
         var topLevel: NSMenu
         var item: NSMenuItem
         if menuItem.parent != nil {
@@ -267,6 +347,53 @@ public class Interactions: NSObject {
             item = menuItem
         }
         return topLevel.index(of: item)
+    }
+
+    private func configuredSavePanel(name: String) -> NSSavePanel {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = name
+        panel.allowedFileTypes = ["txt"]
+        return panel
+    }
+
+    private func defaultFilename(for clipping: Clipping, position: Int) -> String {
+        let base = sanitizedFilename(clipping.shortenedText)
+        let label = base.isEmpty ? "clipping" : base
+        return String(format: "%03d-%@.txt", position + 1, label)
+    }
+
+    private func sanitizedFilename(_ value: String) -> String {
+        let illegal = CharacterSet(charactersIn: "/\\?%*|\"<>:\n\r\t")
+        let pieces = value.components(separatedBy: illegal)
+        let compacted = pieces.joined(separator: " ")
+            .split(separator: " ")
+            .joined(separator: " ")
+        return String(compacted.prefix(40))
+    }
+
+    private func uniqueURL(for filename: String, in directory: URL) -> URL {
+        let manager = FileManager.default
+        let ext = (filename as NSString).pathExtension
+        let base = (filename as NSString).deletingPathExtension
+        var candidate = directory.appendingPathComponent(filename)
+        var counter = 2
+        while manager.fileExists(atPath: candidate.path) {
+            candidate = directory.appendingPathComponent("\(base)-\(counter).\(ext)")
+            counter += 1
+        }
+        return candidate
+    }
+
+    private func write(_ text: String, to url: URL) {
+        do {
+            try text.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = "Unable to save clipping"
+            alert.informativeText = error.localizedDescription
+            _ = alert.runModal()
+        }
     }
 
     private func _clearAll() {

--- a/Jumpcut/Jumpcut/MenuManager.swift
+++ b/Jumpcut/Jumpcut/MenuManager.swift
@@ -43,6 +43,49 @@ public class MenuManager {
         return clipping.shortenedText
     }
 
+    private func menuFont(for clipping: Clipping) -> NSFont {
+        var font = NSFont.menuFont(ofSize: NSFont.systemFontSize)
+        let manager = NSFontManager.shared
+        if clipping.isBold {
+            font = manager.convert(font, toHaveTrait: .boldFontMask)
+        }
+        if clipping.isItalic {
+            font = manager.convert(font, toHaveTrait: .italicFontMask)
+        }
+        return font
+    }
+
+    private func applyMenuStyle(
+        to item: NSMenuItem,
+        for clipping: Clipping,
+        extendedFeaturesEnabled: Bool
+    ) {
+        let title = menuTitle(for: clipping, extendedFeaturesEnabled: extendedFeaturesEnabled)
+        item.title = title
+        guard extendedFeaturesEnabled,
+              (clipping.isBold || clipping.isItalic || clipping.labelColor != nil) else {
+            return
+        }
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: menuFont(for: clipping)
+        ]
+        if let color = clipping.labelColor {
+            attributes[.foregroundColor] = color.menuColor
+        }
+        item.attributedTitle = NSAttributedString(string: title, attributes: attributes)
+    }
+
+    private func styleMenuItem(
+        title: String,
+        action: Selector?,
+        position: Int
+    ) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = delegate!.interactions!
+        item.representedObject = position
+        return item
+    }
+
     private func standardItem(
         forClipping clipping: Clipping,
         position: Int,
@@ -55,6 +98,7 @@ public class MenuManager {
         )
         standardItem.representedObject = position
         standardItem.target = delegate!.interactions!
+        applyMenuStyle(to: standardItem, for: clipping, extendedFeaturesEnabled: extendedFeaturesEnabled)
         return standardItem
     }
 
@@ -70,6 +114,7 @@ public class MenuManager {
             keyEquivalent: ""
         )
         altItem.representedObject = position
+        applyMenuStyle(to: altItem, for: clipping, extendedFeaturesEnabled: extendedFeaturesEnabled)
         let submenu = NSMenu()
         altItem.submenu = submenu
         let placeItem = NSMenuItem(
@@ -90,18 +135,33 @@ public class MenuManager {
         )
         var items = [placeItem, pasteItem]
         if extendedFeaturesEnabled {
-            let saveItem = NSMenuItem(
+            let saveItem = styleMenuItem(
                 title: "Save item to file...",
                 action: #selector(self.delegate!.interactions!.menuSaveItemToFile(sender:)),
-                keyEquivalent: ""
+                position: position
             )
-            let favoriteItem = NSMenuItem(
+            let favoriteItem = styleMenuItem(
                 title: clipping.isFavorite ? "Remove from Favourites" : "Add to Favourites",
                 action: #selector(self.delegate!.interactions!.menuToggleFavorite(sender:)),
-                keyEquivalent: ""
+                position: position
             )
+            let boldItem = styleMenuItem(
+                title: clipping.isBold ? "Remove Bold" : "Make Bold",
+                action: #selector(self.delegate!.interactions!.menuToggleBold(sender:)),
+                position: position
+            )
+            boldItem.state = clipping.isBold ? .on : .off
+            let italicItem = styleMenuItem(
+                title: clipping.isItalic ? "Remove Italic" : "Make Italic",
+                action: #selector(self.delegate!.interactions!.menuToggleItalic(sender:)),
+                position: position
+            )
+            italicItem.state = clipping.isItalic ? .on : .off
             items.append(saveItem)
             items.append(favoriteItem)
+            items.append(boldItem)
+            items.append(italicItem)
+            items.append(colorMenuItem(for: clipping, position: position))
         }
         items.append(deleteItem)
         for item in items {
@@ -110,6 +170,39 @@ public class MenuManager {
             submenu.addItem(item)
         }
         return altItem
+    }
+
+    private func colorMenuItem(for clipping: Clipping, position: Int) -> NSMenuItem {
+        let colorItem = NSMenuItem(title: "Color", action: nil, keyEquivalent: "")
+        colorItem.representedObject = position
+        let colorMenu = NSMenu()
+        colorItem.submenu = colorMenu
+        let noneItem = NSMenuItem(
+            title: "None",
+            action: #selector(self.delegate!.interactions!.menuSetLabelColor(sender:)),
+            keyEquivalent: ""
+        )
+        noneItem.target = delegate!.interactions!
+        noneItem.representedObject = "none"
+        noneItem.state = clipping.labelColor == nil ? .on : .off
+        colorMenu.addItem(noneItem)
+        colorMenu.addItem(NSMenuItem.separator())
+        for color in ClippingLabelColor.allCases {
+            let item = NSMenuItem(
+                title: color.title,
+                action: #selector(self.delegate!.interactions!.menuSetLabelColor(sender:)),
+                keyEquivalent: ""
+            )
+            item.target = delegate!.interactions!
+            item.representedObject = color.rawValue
+            item.state = clipping.labelColor == color ? .on : .off
+            item.attributedTitle = NSAttributedString(
+                string: color.title,
+                attributes: [.foregroundColor: color.menuColor]
+            )
+            colorMenu.addItem(item)
+        }
+        return colorItem
     }
 
     private func addFavoritesMenu(menu: NSMenu, stack: ClippingStack) {
@@ -130,6 +223,7 @@ public class MenuManager {
                 )
                 item.target = delegate!.interactions!
                 item.representedObject = favorite.position
+                applyMenuStyle(to: item, for: favorite.clipping, extendedFeaturesEnabled: true)
                 favoritesMenu.addItem(item)
             }
         }

--- a/Jumpcut/Jumpcut/MenuManager.swift
+++ b/Jumpcut/Jumpcut/MenuManager.swift
@@ -246,8 +246,6 @@ public class MenuManager {
                 displaySize = 10
             }
             let clippings = stack.firstItems(n: displaySize)
-            // No need to call this N times
-            let pasteEnabled = AXIsProcessTrusted()
             for (position, clipping) in clippings.enumerated() {
                 standard.addItem(
                     standardItem(
@@ -260,7 +258,7 @@ public class MenuManager {
                     altItem(
                         forClipping: clipping,
                         position: position,
-                        pasteEnabled: pasteEnabled,
+                        pasteEnabled: true,
                         extendedFeaturesEnabled: extendedFeaturesEnabled
                     )
                 )

--- a/Jumpcut/Jumpcut/MenuManager.swift
+++ b/Jumpcut/Jumpcut/MenuManager.swift
@@ -36,22 +36,40 @@ public class MenuManager {
         return paste
     }
 
-    private func standardItem(forClipping clipping: Clipping) -> NSMenuItem {
+    private func menuTitle(for clipping: Clipping, extendedFeaturesEnabled: Bool) -> String {
+        if extendedFeaturesEnabled && clipping.isFavorite {
+            return "[F] \(clipping.shortenedText)"
+        }
+        return clipping.shortenedText
+    }
+
+    private func standardItem(
+        forClipping clipping: Clipping,
+        position: Int,
+        extendedFeaturesEnabled: Bool
+    ) -> NSMenuItem {
         let standardItem = NSMenuItem(
-            title: clipping.shortenedText,
+            title: menuTitle(for: clipping, extendedFeaturesEnabled: extendedFeaturesEnabled),
             action: #selector(self.delegate!.interactions!.menuSelection(sender:)),
             keyEquivalent: ""
         )
+        standardItem.representedObject = position
         standardItem.target = delegate!.interactions!
         return standardItem
     }
 
-    private func altItem(forClipping clipping: Clipping, pasteEnabled: Bool) -> NSMenuItem {
+    private func altItem(
+        forClipping clipping: Clipping,
+        position: Int,
+        pasteEnabled: Bool,
+        extendedFeaturesEnabled: Bool
+    ) -> NSMenuItem {
         let altItem = NSMenuItem(
-            title: clipping.shortenedText,
+            title: menuTitle(for: clipping, extendedFeaturesEnabled: extendedFeaturesEnabled),
             action: nil,
             keyEquivalent: ""
         )
+        altItem.representedObject = position
         let submenu = NSMenu()
         altItem.submenu = submenu
         let placeItem = NSMenuItem(
@@ -70,16 +88,58 @@ public class MenuManager {
             action: #selector(self.delegate!.interactions!.menuDelete(sender:)),
             keyEquivalent: ""
         )
-        for item in [placeItem, pasteItem, deleteItem] {
+        var items = [placeItem, pasteItem]
+        if extendedFeaturesEnabled {
+            let saveItem = NSMenuItem(
+                title: "Save item to file...",
+                action: #selector(self.delegate!.interactions!.menuSaveItemToFile(sender:)),
+                keyEquivalent: ""
+            )
+            let favoriteItem = NSMenuItem(
+                title: clipping.isFavorite ? "Remove from Favourites" : "Add to Favourites",
+                action: #selector(self.delegate!.interactions!.menuToggleFavorite(sender:)),
+                keyEquivalent: ""
+            )
+            items.append(saveItem)
+            items.append(favoriteItem)
+        }
+        items.append(deleteItem)
+        for item in items {
             item.target = delegate!.interactions!
+            item.representedObject = position
             submenu.addItem(item)
         }
         return altItem
     }
 
+    private func addFavoritesMenu(menu: NSMenu, stack: ClippingStack) {
+        let favoritesMenu = NSMenu()
+        let favoritesItem = NSMenuItem(title: "Favourites", action: nil, keyEquivalent: "")
+        favoritesItem.submenu = favoritesMenu
+        let favorites = stack.favoriteItems()
+        if favorites.isEmpty {
+            let empty = NSMenuItem(title: "<None>", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            favoritesMenu.addItem(empty)
+        } else {
+            for favorite in favorites {
+                let item = NSMenuItem(
+                    title: favorite.clipping.shortenedText,
+                    action: #selector(self.delegate!.interactions!.menuSelection(sender:)),
+                    keyEquivalent: ""
+                )
+                item.target = delegate!.interactions!
+                item.representedObject = favorite.position
+                favoritesMenu.addItem(item)
+            }
+        }
+        menu.addItem(favoritesItem)
+    }
+
     public func rebuild(stack: ClippingStack) {
         standard.removeAllItems()
         alt.removeAllItems()
+        let extendedFeaturesEnabled = Settings.extendedFeaturesEnabled()
         if stack.isEmpty() {
             for which in [alt!, standard!] {
                 which.addItem(withTitle: "<None>", action: nil, keyEquivalent: "")
@@ -95,21 +155,53 @@ public class MenuManager {
             let clippings = stack.firstItems(n: displaySize)
             // No need to call this N times
             let pasteEnabled = AXIsProcessTrusted()
-            for clipping in clippings {
-                standard.addItem(standardItem(forClipping: clipping))
-                alt.addItem(altItem(forClipping: clipping, pasteEnabled: pasteEnabled))
+            for (position, clipping) in clippings.enumerated() {
+                standard.addItem(
+                    standardItem(
+                        forClipping: clipping,
+                        position: position,
+                        extendedFeaturesEnabled: extendedFeaturesEnabled
+                    )
+                )
+                alt.addItem(
+                    altItem(
+                        forClipping: clipping,
+                        position: position,
+                        pasteEnabled: pasteEnabled,
+                        extendedFeaturesEnabled: extendedFeaturesEnabled
+                    )
+                )
             }
         }
         for which in [alt!, standard!] {
-            addFixedMenuItems(menu: which)
+            addFixedMenuItems(menu: which, stack: stack, extendedFeaturesEnabled: extendedFeaturesEnabled)
         }
     }
 
-    func addFixedMenuItems(menu: NSMenu) {
+    func addFixedMenuItems(menu: NSMenu, stack: ClippingStack, extendedFeaturesEnabled: Bool) {
         // Shared between alt and standard menus: Clear All, About,
         // Preferences, and Quit
         let appName = ProcessInfo.processInfo.processName
         menu.addItem(NSMenuItem.separator())
+        if extendedFeaturesEnabled {
+            addFavoritesMenu(menu: menu, stack: stack)
+            let saveAllToFile = NSMenuItem(
+                title: "Save All to File...",
+                action: #selector(self.delegate!.interactions!.saveAllToFile(sender:)),
+                keyEquivalent: ""
+            )
+            saveAllToFile.target = delegate!.interactions!
+            saveAllToFile.isEnabled = !stack.isEmpty()
+            menu.addItem(saveAllToFile)
+            let saveAllAsFiles = NSMenuItem(
+                title: "Save All as Files...",
+                action: #selector(self.delegate!.interactions!.saveAllAsFiles(sender:)),
+                keyEquivalent: ""
+            )
+            saveAllAsFiles.target = delegate!.interactions!
+            saveAllAsFiles.isEnabled = !stack.isEmpty()
+            menu.addItem(saveAllAsFiles)
+        }
         let clear = NSMenuItem(
             title: "Clear All",
             action: #selector(self.delegate!.interactions!.clearAll(sender:)),

--- a/Jumpcut/Jumpcut/MenuManager.swift
+++ b/Jumpcut/Jumpcut/MenuManager.swift
@@ -28,8 +28,7 @@ public class MenuManager {
     }
 
     public func shouldSelectionPaste() -> Bool {
-        var paste =
- UserDefaults.standard.value(forKey: SettingsPath.menuSelectionPastes.rawValue) as? Bool ?? false
+        var paste = Settings.menuSelectionPastes()
         if checkToggle() {
             paste = !paste
         }

--- a/Jumpcut/Jumpcut/Preferences/GeneralPreferenceViewController.swift
+++ b/Jumpcut/Jumpcut/Preferences/GeneralPreferenceViewController.swift
@@ -134,7 +134,12 @@ final class GeneralPreferenceViewController: NSViewController, PreferencePane {
         let (pasteMenu, pasteBezel) = makePasteOptions(settings: settings)
         let wrapBezel = settings.checkbox(title: "Wraparound bezel", key: SettingsPath.wraparoundBezel)
         let stickyBezel = settings.checkbox(title: "Sticky bezel", key: SettingsPath.stickyBezel)
-        let rememberNumView = settings.rangeStepper(title: "Remembering", minValue: 10, maxValue: 99, key: .rememberNum)
+        let rememberNumView = settings.rangeStepper(
+            title: "Remembering",
+            minValue: 10,
+            maxValue: Settings.maximumRememberNum(),
+            key: .rememberNum
+        )
         let displayNumView = settings.rangeStepper(title: "Displaying", minValue: 10, maxValue: 99, key: .displayNum)
         let stepperViews = NSStackView(views: [rememberNumView, displayNumView])
         NSLayoutConstraint.activate([

--- a/Jumpcut/Jumpcut/Preferences/HotkeyPreferenceViewController.swift
+++ b/Jumpcut/Jumpcut/Preferences/HotkeyPreferenceViewController.swift
@@ -19,13 +19,34 @@ final class HotkeyPreferenceViewController: NSViewController, PreferencePane {
     }
     override var nibName: NSNib.Name? { nil }
 
+    @objc func toggleExtendedFeatures(sender: NSButton) {
+        guard sender.state == .off else {
+            return
+        }
+        let rememberNum = UserDefaults.standard.value(
+            forKey: SettingsPath.rememberNum.rawValue
+        ) as? Int ?? Settings.defaultRememberNum()
+        if rememberNum > Settings.defaultRememberNum() {
+            UserDefaults.standard.set(
+                Settings.defaultRememberNum(),
+                forKey: SettingsPath.rememberNum.rawValue
+            )
+        }
+    }
+
     override func viewDidLoad() {
         let settings = Settings()
         toolbarItemIcon.isTemplate = true
-        self.preferredContentSize = CGSize(width: 480, height: 180)
+        self.preferredContentSize = CGSize(width: 480, height: 220)
         super.viewDidLoad()
         let recorder = settings.shortcutRecorder(title: "Main hotkey", key: .mainHotkey)
-        let grid = NSStackView(views: [ recorder ])
+        let extendedFeatures = settings.checkbox(
+            title: "Enable extended clipping actions and 500-item history",
+            key: .extendedFeaturesEnabled,
+            target: self,
+            action: #selector(self.toggleExtendedFeatures)
+        )
+        let grid = NSStackView(views: [ recorder, extendedFeatures ])
         grid.orientation = .vertical
         grid.alignment = .leading
         self.view.addSubview(grid)

--- a/Jumpcut/Jumpcut/Settings.swift
+++ b/Jumpcut/Jumpcut/Settings.swift
@@ -241,6 +241,17 @@ public class Settings: NSObject {
         return UserDefaults.standard.object(forKey: SettingsPath.menuSelectionPastes.rawValue) as? Bool ?? true
     }
 
+    class func pasteAccessibilityTrusted(prompt: Bool = false) -> Bool {
+        let trusted = AXIsProcessTrusted()
+        guard !trusted && prompt else {
+            return trusted
+        }
+        let options = [
+            kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true
+        ] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+    }
+
     private func setAttributedTitle(button: NSButton, title: String) {
         let font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
         let attributes = [NSAttributedString.Key.font: font]

--- a/Jumpcut/Jumpcut/Settings.swift
+++ b/Jumpcut/Jumpcut/Settings.swift
@@ -237,6 +237,10 @@ public class Settings: NSObject {
         return min(requested, maximumRememberNum())
     }
 
+    class func menuSelectionPastes() -> Bool {
+        return UserDefaults.standard.object(forKey: SettingsPath.menuSelectionPastes.rawValue) as? Bool ?? true
+    }
+
     private func setAttributedTitle(button: NSButton, title: String) {
         let font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
         let attributes = [NSAttributedString.Key.font: font]

--- a/Jumpcut/Jumpcut/Settings.swift
+++ b/Jumpcut/Jumpcut/Settings.swift
@@ -23,6 +23,7 @@ enum SettingsPath: String {
     case bezelToTop
     case checkForUpdates
     case displayNum
+    case extendedFeaturesEnabled
     case hideStatusItem
     case ignoreLargeClippings
     case ignoreSensitiveClippingTypes
@@ -62,6 +63,7 @@ private let settingsDefaults: [String: Any] = [
     SettingsPath.bezelToTop.rawValue: 1,
     SettingsPath.checkForUpdates.rawValue: false,
     SettingsPath.displayNum.rawValue: 10,
+    SettingsPath.extendedFeaturesEnabled.rawValue: false,
     SettingsPath.hideStatusItem.rawValue: false,
     SettingsPath.ignoreLargeClippings.rawValue: true,
     SettingsPath.ignoreSensitiveClippingTypes.rawValue: true,
@@ -182,12 +184,23 @@ public class PreferencePopupButton: NSPopUpButton {
 public class Settings: NSObject {
     let standardDefaults = UserDefaults.standard
     let continuous = [NSBindingOption.continuouslyUpdatesValue: true]
+    private static let standardRememberLimit = 99
+    private static let extendedRememberLimit = 500
 
     class func registerDefaults() {
         let userDefaults = UserDefaults.standard
+        let hadExtendedFeaturesPreference = userDefaults.object(
+            forKey: SettingsPath.extendedFeaturesEnabled.rawValue
+        ) != nil
+        let existingRememberNum = userDefaults.object(forKey: SettingsPath.rememberNum.rawValue) as? Int
         userDefaults.register(
             defaults: settingsDefaults
         )
+        if !hadExtendedFeaturesPreference,
+           let rememberNum = existingRememberNum,
+           rememberNum > standardRememberLimit {
+            userDefaults.set(true, forKey: SettingsPath.extendedFeaturesEnabled.rawValue)
+        }
      }
 
     class func reset() {
@@ -202,6 +215,27 @@ public class Settings: NSObject {
             #endif
         }
      }
+
+    class func extendedFeaturesEnabled() -> Bool {
+        return UserDefaults.standard.value(
+            forKey: SettingsPath.extendedFeaturesEnabled.rawValue
+        ) as? Bool ?? false
+    }
+
+    class func maximumRememberNum() -> Int {
+        return extendedFeaturesEnabled() ? extendedRememberLimit : standardRememberLimit
+    }
+
+    class func defaultRememberNum() -> Int {
+        return standardRememberLimit
+    }
+
+    class func effectiveRememberNum() -> Int {
+        let requested = UserDefaults.standard.value(
+            forKey: SettingsPath.rememberNum.rawValue
+        ) as? Int ?? standardRememberLimit
+        return min(requested, maximumRememberNum())
+    }
 
     private func setAttributedTitle(button: NSButton, title: String) {
         let font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
@@ -293,7 +327,7 @@ public class Settings: NSObject {
         let stpLabel = makeLabel(title: title)
         stpLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
         let stpDisplay = makeLabel(title: "")
-        stpDisplay.preferredMaxLayoutWidth = CGFloat(15.0)
+        stpDisplay.preferredMaxLayoutWidth = CGFloat(34.0)
         stp.bind(.value,
                  to: UserDefaults.standard,
                  withKeyPath: key.rawValue,

--- a/Jumpcut/JumpcutTests/JumpcutTests.swift
+++ b/Jumpcut/JumpcutTests/JumpcutTests.swift
@@ -97,4 +97,30 @@ class JumpcutTests: XCTestCase {
         XCTAssertTrue(stack.itemAt(position: 0)?.isFavorite ?? false)
     }
 
+    func testClippingStylesCanBeToggledAndMoveWithClipping() throws {
+        let stack = ClippingStack()
+        stack.add(item: "plain")
+        stack.add(item: "styled")
+
+        stack.toggleBold(position: 1)
+        stack.toggleItalic(position: 1)
+        stack.setLabelColor(position: 1, color: .green)
+
+        XCTAssertFalse(stack.itemAt(position: 0)?.isBold ?? true)
+        XCTAssertTrue(stack.itemAt(position: 1)?.isBold ?? false)
+        XCTAssertTrue(stack.itemAt(position: 1)?.isItalic ?? false)
+        XCTAssertEqual(stack.itemAt(position: 1)?.labelColor, .green)
+
+        stack.moveItemToTop(position: 1)
+
+        XCTAssertEqual(stack.itemAt(position: 0)?.fullText, "plain")
+        XCTAssertTrue(stack.itemAt(position: 0)?.isBold ?? false)
+        XCTAssertTrue(stack.itemAt(position: 0)?.isItalic ?? false)
+        XCTAssertEqual(stack.itemAt(position: 0)?.labelColor, .green)
+
+        stack.setLabelColor(position: 0, color: nil)
+
+        XCTAssertNil(stack.itemAt(position: 0)?.labelColor)
+    }
+
 }

--- a/Jumpcut/JumpcutTests/JumpcutTests.swift
+++ b/Jumpcut/JumpcutTests/JumpcutTests.swift
@@ -12,12 +12,16 @@ class JumpcutTests: XCTestCase {
     private var previousRememberNum: Any?
     private var previousSkipSave: Any?
     private var previousExtendedFeaturesEnabled: Any?
+    private var previousMenuSelectionPastes: Any?
 
     override func setUpWithError() throws {
         previousRememberNum = UserDefaults.standard.object(forKey: SettingsPath.rememberNum.rawValue)
         previousSkipSave = UserDefaults.standard.object(forKey: SettingsPath.skipSave.rawValue)
         previousExtendedFeaturesEnabled = UserDefaults.standard.object(
             forKey: SettingsPath.extendedFeaturesEnabled.rawValue
+        )
+        previousMenuSelectionPastes = UserDefaults.standard.object(
+            forKey: SettingsPath.menuSelectionPastes.rawValue
         )
         UserDefaults.standard.set(500, forKey: SettingsPath.rememberNum.rawValue)
         UserDefaults.standard.set(true, forKey: SettingsPath.skipSave.rawValue)
@@ -28,6 +32,7 @@ class JumpcutTests: XCTestCase {
         restore(previousRememberNum, forKey: SettingsPath.rememberNum)
         restore(previousSkipSave, forKey: SettingsPath.skipSave)
         restore(previousExtendedFeaturesEnabled, forKey: SettingsPath.extendedFeaturesEnabled)
+        restore(previousMenuSelectionPastes, forKey: SettingsPath.menuSelectionPastes)
     }
 
     private func restore(_ value: Any?, forKey key: SettingsPath) {
@@ -49,6 +54,12 @@ class JumpcutTests: XCTestCase {
         XCTAssertEqual(stack.itemAt(position: 0)?.fullText, "clip 549")
         XCTAssertEqual(stack.itemAt(position: 499)?.fullText, "clip 50")
         XCTAssertNil(stack.itemAt(position: 500))
+    }
+
+    func testMenuSelectionDefaultsToPasteWhenPreferenceIsMissing() throws {
+        UserDefaults.standard.removeObject(forKey: SettingsPath.menuSelectionPastes.rawValue)
+
+        XCTAssertTrue(Settings.menuSelectionPastes())
     }
 
     func testExtendedHistoryRequiresOptIn() throws {

--- a/Jumpcut/JumpcutTests/JumpcutTests.swift
+++ b/Jumpcut/JumpcutTests/JumpcutTests.swift
@@ -9,29 +9,92 @@ import XCTest
 @testable import Jumpcut
 
 class JumpcutTests: XCTestCase {
+    private var previousRememberNum: Any?
+    private var previousSkipSave: Any?
+    private var previousExtendedFeaturesEnabled: Any?
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        previousRememberNum = UserDefaults.standard.object(forKey: SettingsPath.rememberNum.rawValue)
+        previousSkipSave = UserDefaults.standard.object(forKey: SettingsPath.skipSave.rawValue)
+        previousExtendedFeaturesEnabled = UserDefaults.standard.object(
+            forKey: SettingsPath.extendedFeaturesEnabled.rawValue
+        )
+        UserDefaults.standard.set(500, forKey: SettingsPath.rememberNum.rawValue)
+        UserDefaults.standard.set(true, forKey: SettingsPath.skipSave.rawValue)
+        UserDefaults.standard.set(true, forKey: SettingsPath.extendedFeaturesEnabled.rawValue)
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        restore(previousRememberNum, forKey: SettingsPath.rememberNum)
+        restore(previousSkipSave, forKey: SettingsPath.skipSave)
+        restore(previousExtendedFeaturesEnabled, forKey: SettingsPath.extendedFeaturesEnabled)
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encountersan uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete.
-        // Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    private func restore(_ value: Any?, forKey key: SettingsPath) {
+        if let value = value {
+            UserDefaults.standard.set(value, forKey: key.rawValue)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key.rawValue)
         }
+    }
+
+    func testStackCanRememberFiveHundredClippings() throws {
+        let stack = ClippingStack()
+
+        for index in 0 ..< 550 {
+            stack.add(item: "clip \(index)")
+        }
+
+        XCTAssertEqual(stack.count, 500)
+        XCTAssertEqual(stack.itemAt(position: 0)?.fullText, "clip 549")
+        XCTAssertEqual(stack.itemAt(position: 499)?.fullText, "clip 50")
+        XCTAssertNil(stack.itemAt(position: 500))
+    }
+
+    func testExtendedHistoryRequiresOptIn() throws {
+        UserDefaults.standard.set(false, forKey: SettingsPath.extendedFeaturesEnabled.rawValue)
+        let stack = ClippingStack()
+
+        for index in 0 ..< 120 {
+            stack.add(item: "clip \(index)")
+        }
+
+        XCTAssertEqual(stack.count, 99)
+        XCTAssertEqual(stack.itemAt(position: 0)?.fullText, "clip 119")
+        XCTAssertEqual(stack.itemAt(position: 98)?.fullText, "clip 21")
+        XCTAssertNil(stack.itemAt(position: 99))
+    }
+
+    func testSyncSettingsTrimsToRememberLimit() throws {
+        let stack = ClippingStack()
+        for index in 0 ..< 25 {
+            stack.add(item: "clip \(index)")
+        }
+
+        UserDefaults.standard.set(10, forKey: SettingsPath.rememberNum.rawValue)
+        stack.syncSettings()
+
+        XCTAssertEqual(stack.count, 10)
+        XCTAssertEqual(stack.itemAt(position: 0)?.fullText, "clip 24")
+        XCTAssertEqual(stack.itemAt(position: 9)?.fullText, "clip 15")
+    }
+
+    func testFavoritesCanBeToggledAndMoveWithClipping() throws {
+        let stack = ClippingStack()
+        stack.add(item: "first")
+        stack.add(item: "second")
+
+        stack.toggleFavorite(position: 1)
+
+        XCTAssertFalse(stack.itemAt(position: 0)?.isFavorite ?? true)
+        XCTAssertTrue(stack.itemAt(position: 1)?.isFavorite ?? false)
+        XCTAssertEqual(stack.favoriteItems().first?.position, 1)
+        XCTAssertEqual(stack.favoriteItems().first?.clipping.fullText, "first")
+
+        stack.moveItemToTop(position: 1)
+
+        XCTAssertEqual(stack.itemAt(position: 0)?.fullText, "first")
+        XCTAssertTrue(stack.itemAt(position: 0)?.isFavorite ?? false)
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Preferences to use them.
 * Individual clippings can be marked as favourites from the alternate clipping
   menu. Favourites are marked with `[F]` and are available from a dedicated
   Favourites submenu.
+* Clippings can be visually labelled from the alternate clipping menu with
+  bold, italic, and a small color palette. These labels are visible in the main
+  clipping menu, the alternate menu, and the Favourites submenu.
 * Clippings can be saved to disk: save a selected clipping to a file, save all
   clippings into one text file, or save all clippings as separate text files.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ opening Jumpcut's alternate clipping menu (for example, right-click or
 Shift-click the menu bar icon, depending on your preferences), hovering the
 clipping, and choosing **Add to Favourites**.
 
+For menu clicks to paste directly into another app, macOS must allow Jumpcut
+under **System Settings > Privacy & Security > Accessibility**. If selecting a
+clipping updates the pasteboard but does not paste into the editor, enable
+Jumpcut in Accessibility and restart Jumpcut. Without that permission Jumpcut
+can still copy the clipping to the pasteboard, but macOS blocks the synthetic
+Command-V event used for paste.
+
 I made these changes for my own benefit and have sent a PR. They are most
 likely not useful to others and they kind of violate the minimalism of Jumpcut,
 but hey - works for me.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ else.
 Jumpcut has a lightweight, intuitive interface and is 100% focused on
 your clipboard, keeping code snippets, email addresses, URLs, and that
 sentence that you actually had _just right_ five minutes ago close to hand.
+
+This fork adds a few larger-workflow conveniences. They are off by default;
+enable **Hotkey > Enable extended clipping actions and 500-item history** in
+Preferences to use them.
+
+* The clipping history can remember up to 500 items.
+* Individual clippings can be marked as favourites from the alternate clipping
+  menu. Favourites are marked with `[F]` and are available from a dedicated
+  Favourites submenu.
+* Clippings can be saved to disk: save a selected clipping to a file, save all
+  clippings into one text file, or save all clippings as separate text files.
+
+After enabling extended clipping actions, add a clipping to favourites by
+opening Jumpcut's alternate clipping menu (for example, right-click or
+Shift-click the menu bar icon, depending on your preferences), hovering the
+clipping, and choosing **Add to Favourites**.
+
+I made these changes for my own benefit and have sent a PR. They are most
+likely not useful to others and they kind of violate the minimalism of Jumpcut,
+but hey - works for me.


### PR DESCRIPTION
## Summary

This PR adds an opt-in set of larger-workflow clipboard tools to my Jumpcut fork:

- Optional extended clipping mode in Hotkey preferences.
- Up to 500 remembered clippings when extended mode is enabled.
- Favourite clippings with a Favourites submenu.
- Bold, italic, and color labels for clippings, visible in the main menu, alternate menu, and Favourites submenu.
- Save selected clipping, save all clippings to one text file, or save all clippings as separate text files.
- Documentation for the new features and for the macOS Accessibility permission required for direct paste.

I made these changes for my own workflow. They probably are not broadly useful, and they do push against Jumpcut's minimalism, but they are opt-in and they work for my usage.

## Fixes Included

- Menu selection now defaults to paste behavior even when `menuSelectionPastes` has never been persisted.
- If macOS blocks synthetic Command-V because Jumpcut lacks Accessibility permission, paste attempts request trust and explain the copy-only symptom.

## Validation

- `xcodebuild test -project Jumpcut/Jumpcut.xcodeproj -scheme Jumpcut -destination 'platform=macOS' -derivedDataPath ./DerivedData CODE_SIGNING_ALLOWED=NO MACOSX_DEPLOYMENT_TARGET=10.13`
- `xcodebuild build -project Jumpcut/Jumpcut.xcodeproj -scheme Jumpcut -configuration Release -destination 'platform=macOS' -derivedDataPath ./DerivedData CODE_SIGNING_ALLOWED=NO MACOSX_DEPLOYMENT_TARGET=10.13`
- `codesign --verify --deep --strict --verbose=2 /Applications/Jumpcut.app`
- `git diff --check`

## Notes

This is opened as a draft because it is a personal fork feature set rather than a clearly upstream-shaped minimal change.
